### PR TITLE
Update user-agent to macOS Chrome 147

### DIFF
--- a/classes/orbis-monitoring-plugin.php
+++ b/classes/orbis-monitoring-plugin.php
@@ -304,7 +304,7 @@ class Orbis_Monitoring_Plugin extends Orbis_Plugin {
 				 * @link http://www.browser-info.net/useragents
 				 * @link https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome
 				 */
-				'user-agent'  => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
+				'user-agent'  => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36',
 			)
 		);
 


### PR DESCRIPTION
Change the default 'user-agent' header in classes/orbis-monitoring-plugin.php from a Windows Chrome 108 string to a macOS Chrome 147 string. This updates the agent used for monitoring requests so remote sites may render/respond as a recent macOS Chrome browser.